### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ docker:
 
 .PHONY: shell
 shell:
-	docker run -ti -v ${CURRENT_DIR}:/data --workdir=/data opencv_cuda_build bash
-
+	docker run --gpus all -ti -v ${CURRENT_DIR}:/data --workdir=/data opencv_cuda_build bash
+	#With the command "--gpus all" the container has access to the GPU.


### PR DESCRIPTION
Without "--gpus all" you will receive an error like this:

root@dd56267eceb5:/data# time bin/resizegpu MyImage.jpg
terminate called after throwing an instance of 'cv::Exception' what(): OpenCV(4.1.1) /build/opencv-4.1.1/modules/core/src/cuda/gpu_mat.cu:116: error: (-217:Gpu API call) CUDA driver version is insufficient for CUDA runtime version in function 'allocate'
Aborted (core dumped)